### PR TITLE
Simple Bug Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,28 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.10.4</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/io/swagger/client/JSON.java
+++ b/src/main/java/io/swagger/client/JSON.java
@@ -47,6 +47,7 @@ import java.util.Date;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
 
 public class JSON {

--- a/src/main/java/io/swagger/client/JSON.java
+++ b/src/main/java/io/swagger/client/JSON.java
@@ -181,30 +181,41 @@ class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
  * Gson TypeAdapter for Joda DateTime type
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
-
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
-
-    @Override
-    public void write(JsonWriter out, DateTime date) throws IOException {
-        if (date == null) {
-            out.nullValue();
-        } else {
-            out.value(formatter.print(date));
+    
+        private final DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder()
+                                                        .appendPattern("MM/dd/yyyy HH:mm:ss z")
+                                                        .toFormatter();
+    
+        private final DateTimeFormatter timeFormatter = new DateTimeFormatterBuilder()
+                                                        .appendPattern("HH:mm:ss z")
+                                                        .toFormatter();
+    
+        @Override
+        public void write(JsonWriter out, DateTime date) throws IOException {
+            if (date == null) {
+                out.nullValue();
+            } else {
+                out.value(dateFormatter.print(date));
+            }
+        }
+    
+        @Override
+        public DateTime read(JsonReader in) throws IOException {
+            switch (in.peek()) {
+                case NULL:
+                    in.nextNull();
+                    return null;
+                default:
+                    String date = in.nextString();
+                    try{
+                        return timeFormatter.parseDateTime(date);
+                    }
+                    catch(IllegalArgumentException e){
+                        return dateFormatter.parseDateTime(date);
+                    }
+            }
         }
     }
-
-    @Override
-    public DateTime read(JsonReader in) throws IOException {
-        switch (in.peek()) {
-            case NULL:
-                in.nextNull();
-                return null;
-            default:
-                String date = in.nextString();
-                return formatter.parseDateTime(date);
-        }
-    }
-}
 
 /**
  * Gson TypeAdapter for Joda LocalDate type

--- a/src/main/java/io/swagger/client/api/ProcessgroupsApi.java
+++ b/src/main/java/io/swagger/client/api/ProcessgroupsApi.java
@@ -2826,8 +2826,8 @@ public class ProcessgroupsApi {
      * @return TemplateEntity
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public TemplateEntity uploadTemplate(String id, File template) throws ApiException {
-        ApiResponse<TemplateEntity> resp = uploadTemplateWithHttpInfo(id, template);
+    public String uploadTemplate(String id, File template) throws ApiException {
+        ApiResponse<String> resp = uploadTemplateWithHttpInfo(id, template);
         return resp.getData();
     }
 
@@ -2839,9 +2839,9 @@ public class ProcessgroupsApi {
      * @return ApiResponse&lt;TemplateEntity&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<TemplateEntity> uploadTemplateWithHttpInfo(String id, File template) throws ApiException {
+    public ApiResponse<String> uploadTemplateWithHttpInfo(String id, File template) throws ApiException {
         com.squareup.okhttp.Call call = uploadTemplateCall(id, template, null, null);
-        Type localVarReturnType = new TypeToken<TemplateEntity>(){}.getType();
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
 

--- a/src/main/java/io/swagger/client/api/TemplatesApi.java
+++ b/src/main/java/io/swagger/client/api/TemplatesApi.java
@@ -121,8 +121,8 @@ public class TemplatesApi {
      * @return TemplateDTO
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public TemplateDTO exportTemplate(String id) throws ApiException {
-        ApiResponse<TemplateDTO> resp = exportTemplateWithHttpInfo(id);
+    public String exportTemplate(String id) throws ApiException {
+        ApiResponse<String> resp = exportTemplateWithHttpInfo(id);
         return resp.getData();
     }
 
@@ -133,9 +133,9 @@ public class TemplatesApi {
      * @return ApiResponse&lt;TemplateDTO&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<TemplateDTO> exportTemplateWithHttpInfo(String id) throws ApiException {
+    public ApiResponse<String> exportTemplateWithHttpInfo(String id) throws ApiException {
         com.squareup.okhttp.Call call = exportTemplateCall(id, null, null);
-        Type localVarReturnType = new TypeToken<TemplateDTO>(){}.getType();
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
 

--- a/src/main/java/io/swagger/client/model/LabelDTO.java
+++ b/src/main/java/io/swagger/client/model/LabelDTO.java
@@ -179,7 +179,7 @@ public class LabelDTO {
   }
 
    /**
-   * The styles for this label (font-size => 12px, background-color => #eee, etc).
+   * The styles for this label (font-size =&gt; 12px, background-color =&gt; #eee, etc).
    * @return style
   **/
   @ApiModelProperty(example = "null", value = "The styles for this label (font-size => 12px, background-color => #eee, etc).")

--- a/src/main/java/io/swagger/client/model/ProcessorDTO.java
+++ b/src/main/java/io/swagger/client/model/ProcessorDTO.java
@@ -234,7 +234,7 @@ public class ProcessorDTO {
   }
 
    /**
-   * Styles for the processor (background-color => #eee).
+   * Styles for the processor (background-color =&gt; #eee).
    * @return style
   **/
   @ApiModelProperty(example = "null", value = "Styles for the processor (background-color => #eee).")


### PR DESCRIPTION
Export template now returns a String since the response is a Application/XML.
The DateTimeTypeAdapter has been updated to work with the dates in the responses
of version 1.3.0
Fixed some formatting errors that were being thrown when generating JavaDoc
Addresses Issue #1 